### PR TITLE
sanitise BPM input to numbers only

### DIFF
--- a/js/guess-tempo.js
+++ b/js/guess-tempo.js
@@ -57,6 +57,11 @@
 
     var guessedBpm = guessedTempoEl.val();
     guessedTempoEl.val('');
+    
+    if(typeof guessedBpm == "string") {
+      guessedBpm = parseInt(guessedBpm);
+      if(isNaN(guessedBpm)) guessedBpm = 0;
+    }
 
     scoreEl.removeClass('hidden');
 


### PR DESCRIPTION
If input BPM is a string (for instance: contains spaces, accidentally hit another key while pressing enter, etc), attempts are made to parse integer from it. If no number could be found (player entered gibberish or typed out number as words), guessedBpm will be set to 0.