### PR TITLE
Auto-focus on tempo input in guess tempo game

### DIFF
--- a/js/guess-tempo.js
+++ b/js/guess-tempo.js
@@ -38,6 +38,7 @@
   function onPlayFinish() {
     speakerEl.addClass('hidden');
     formEl.removeClass('hidden');
+    guessedTempoEl.focus();
   }
 
   function onReadyClick() {


### PR DESCRIPTION
Auto-focus on the input field for ease of use.
When tempo finishes playing, the input field will be already focused
to avoid an extra click every time.